### PR TITLE
Add exclude param to prevent processing certain files

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,16 +12,21 @@ function importTwinMacroPlugin(babel) {
       Program: (path, state) => {
         let shouldAddImport = true;
         const hasDebug = state.opts.debug === true;
+        const exclude = state.opts.exclude ?? [];
+        
+        if (exclude.some(r => r.test(state.file.opts.filename))) {
+          shouldAddImport = false;
+        } else {
+          state.file.path.traverse({
+            ImportDeclaration(path) {
+              // Find the twin import path
+              if (path.node.source.value !== "twin.macro") return;
+              shouldAddImport = false;
+            },
 
-        state.file.path.traverse({
-          ImportDeclaration(path) {
-            // Find the twin import path
-            if (path.node.source.value !== "twin.macro") return;
-            shouldAddImport = false;
-          },
-
-          // TODO: Alert on usage of tw when no `import tw from "twin.macro"`
-        });
+            // TODO: Alert on usage of tw when no `import tw from "twin.macro"`
+          });
+        }
 
         if (!shouldAddImport) {
           hasDebug &&


### PR DESCRIPTION
Certain configurations of babel will cause files that are not part of the project to be processed, triggering a subsequent error when it attempts to import twin.macro from a 3rd party project that doesn't include it.

The exclude array takes a list of regexes (`\.yarn\` in my case) and ensures that the file name doesn't match any of them.